### PR TITLE
feat(counter): add counter to each UserDisplay

### DIFF
--- a/src/components/SectionFollowers.jsx
+++ b/src/components/SectionFollowers.jsx
@@ -99,7 +99,7 @@ function SectionFollowers({ username }) {
               )}
             >
               <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Followers
-                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-green-500 rounded-full")}>
+                <span className={clsx("ml-2 px-2 py-1 text-sm text-white bg-green-500 square-full")}>
                   {followers.length}
                 </span>
               </h1>
@@ -114,7 +114,7 @@ function SectionFollowers({ username }) {
               )}
             >
               <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Following
-                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-blue-500 rounded-full")}>
+                <span className={clsx("ml-2 px-2 py-1 text-sm text-white bg-blue-500 square-full")}>
                   {following.length}
                 </span>
               </h1>
@@ -129,7 +129,7 @@ function SectionFollowers({ username }) {
               )}
             >
               <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>You don't follow back
-                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-purple-500 rounded-full")}>
+                <span className={clsx("ml-2 px-2 py-1 text-sm text-white bg-purple-500 square-full")}>
                   {youDontFollowBack.length}
                 </span>
               </h1>
@@ -143,7 +143,7 @@ function SectionFollowers({ username }) {
               )}
             >
               <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Doesn't follow back
-                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-red-500 rounded-full")}>
+                <span className={clsx("ml-2 px-2 py-1 text-sm text-white bg-red-500 square-full")}>
                   {doesntFollowBack.length}
                 </span>
               </h1>

--- a/src/components/SectionFollowers.jsx
+++ b/src/components/SectionFollowers.jsx
@@ -98,7 +98,11 @@ function SectionFollowers({ username }) {
                 "md:mr-10",
               )}
             >
-              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Followers</h1>
+              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Followers
+                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-green-500 rounded-full")}>
+                  {followers.length}
+                </span>
+              </h1>
               <UsersDisplay users={followers} />
             </div>
             <div
@@ -109,7 +113,11 @@ function SectionFollowers({ username }) {
                 "md:mr-10",
               )}
             >
-              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Following</h1>
+              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Following
+                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-blue-500 rounded-full")}>
+                  {following.length}
+                </span>
+              </h1>
               <UsersDisplay users={following} />
             </div>
             <div
@@ -120,7 +128,11 @@ function SectionFollowers({ username }) {
                 "md:mr-10",
               )}
             >
-              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>You don't follow back</h1>
+              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>You don't follow back
+                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-purple-500 rounded-full")}>
+                  {youDontFollowBack.length}
+                </span>
+              </h1>
               <UsersDisplay users={youDontFollowBack} />
             </div>
             <div
@@ -130,7 +142,11 @@ function SectionFollowers({ username }) {
                 "mb-5 md:mb-0",
               )}
             >
-              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Doesn't follow back</h1>
+              <h1 className={clsx("text-lg font-bold", "mb-1 md:mb-3")}>Doesn't follow back
+                <span className={clsx("ml-1 w-1/3 px-2 pb-1 text-sm text-white bg-red-500 rounded-full")}>
+                  {doesntFollowBack.length}
+                </span>
+              </h1>
               <UsersDisplay users={doesntFollowBack} />
             </div>
           </>


### PR DESCRIPTION
You can change the color themes, now they are in tailwind 500, to follow the standard in the code

## What?

I added a color counter to each UserDisplay

## Why?

I found it necessary and useful

## How?

Using tailwind css

## Screnshots

In my case, looks like this:
![image](https://user-images.githubusercontent.com/50716449/176025380-b9fab849-9a64-4147-b690-203fc0028d89.png)